### PR TITLE
Update mongoose to 5.x

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -60,7 +60,7 @@ class Socket {
       config.logger(connectionString);
     }
     const opts = config.options || {};
-    opts.useMongoClient = true;
+    opts.useNewUrlParser = true;
     const connection = mongoose.createConnection(connectionString, opts);
     connection.on('error', err => {
       this.config.logger(err);

--- a/package.json
+++ b/package.json
@@ -23,17 +23,17 @@
     }
   ],
   "dependencies": {
-    "mongoose": "^4.11.7",
-    "think-helper": "^1.0.20",
+    "mongoose": "^5.2.10",
+    "think-helper": "^1.1.2",
     "think-instance": "^1.0.1"
   },
   "devDependencies": {
-    "ava": "^0.18.0",
-    "eslint": "^4.2.0",
+    "ava": "^0.25.0",
+    "eslint": "^5.4.0",
     "eslint-config-think": "^1.0.2",
     "mkdirp": "^0.5.1",
-    "mock-require": "^2.0.1",
-    "nyc": "^7.0.0",
+    "mock-require": "^3.0.2",
+    "nyc": "^13.0.1",
     "pre-commit": "^1.2.2"
   },
   "keywords": [


### PR DESCRIPTION
* Update dependencies
* Remove `opts.useMongoClient = true` in `socket.js`, no longer needing `useMongoClient` in mongoose 5.x
* Add `opts.useNewUrlParser = true` to avoid DeprecationWarning:
```bash
DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.
```